### PR TITLE
feat: fork release workflow — build tarball on tag, install from URL

### DIFF
--- a/.github/workflows/fork-release.yml
+++ b/.github/workflows/fork-release.yml
@@ -1,0 +1,24 @@
+name: Fork Release
+
+on:
+  push:
+    tags:
+      - 'v*-thompsonson.*'
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+      - run: npm ci
+      - run: npm run build
+      - run: npm pack --pack-destination .
+      - run: mv codeburn-*.tgz codeburn.tgz
+      - uses: softprops/action-gh-release@v2
+        with:
+          files: codeburn.tgz

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "codeburn",
-  "version": "0.9.1-thompsonson.3",
+  "version": "0.9.1-thompsonson.4",
   "description": "See where your AI coding tokens go - by task, tool, model, and project",
   "type": "module",
   "main": "./dist/cli.js",
@@ -14,7 +14,7 @@
     "build": "tsup",
     "dev": "tsx src/cli.ts",
     "test": "vitest",
-    "prepare": "npx --yes tsup",
+    "prepare": "npm run build",
     "prepublishOnly": "npm run build"
   },
   "keywords": [


### PR DESCRIPTION
## Summary
- New workflow `.github/workflows/fork-release.yml` triggers on `v*-thompsonson.*` tags
- CI runs `npm ci && npm run build && npm pack`, renames to `codeburn.tgz`, attaches to GitHub release
- chezmoi installs via `npm install -g <release-tarball-url>` — no build at install time

## Why
`npm install -g <github-url>` fights with npm's `--force` flag and devDependency install ordering. Installing from a pre-built tarball bypasses all of that — npm just downloads, extracts, and links the binary.

Closes #7. Supersedes #8.