### PR TITLE
chore: bump to 0.9.1-thompsonson.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "codeburn",
-  "version": "0.9.1-thompsonson.4",
+  "version": "0.9.1-thompsonson.5",
   "description": "See where your AI coding tokens go - by task, tool, model, and project",
   "type": "module",
   "main": "./dist/cli.js",


### PR DESCRIPTION
Version bump for PR #12 (message_id + inline correction text). Merge to trigger release tag.